### PR TITLE
fix: fix architecture type for Windows ARM64 in GetCommandTests and Kustomize

### DIFF
--- a/Devantler.KustomizeCLI.Tests/KustomizeTests/GetCommandTests.cs
+++ b/Devantler.KustomizeCLI.Tests/KustomizeTests/GetCommandTests.cs
@@ -16,7 +16,7 @@ public class GetCommandTests
   [InlineData(PlatformID.Unix, Architecture.X64, "linux-x64", "kustomize-linux-x64")]
   [InlineData(PlatformID.Unix, Architecture.Arm64, "linux-arm64", "kustomize-linux-arm64")]
   [InlineData(PlatformID.Win32NT, Architecture.X64, "win-x64", "kustomize-win-x64.exe")]
-  [InlineData(PlatformID.Win32NT, Architecture.X64, "win-arm64", "kustomize-win-arm64.exe")]
+  [InlineData(PlatformID.Win32NT, Architecture.Arm64, "win-arm64", "kustomize-win-arm64.exe")]
   public void GetCommand_ShouldReturnOSXx64Binary(PlatformID platformID, Architecture architecture, string runtimeIdentifier, string expectedBinary)
   {
     // Act

--- a/Devantler.KustomizeCLI/Kustomize.cs
+++ b/Devantler.KustomizeCLI/Kustomize.cs
@@ -26,7 +26,7 @@ public static class Kustomize
       (PlatformID.Unix, Architecture.X64, "linux-x64") => "kustomize-linux-x64",
       (PlatformID.Unix, Architecture.Arm64, "linux-arm64") => "kustomize-linux-arm64",
       (PlatformID.Win32NT, Architecture.X64, "win-x64") => "kustomize-win-x64.exe",
-      (PlatformID.Win32NT, Architecture.arm64, "win-arm64") => "kustomize-win-arm64.exe",
+      (PlatformID.Win32NT, Architecture.Arm64, "win-arm64") => "kustomize-win-arm64.exe",
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);

--- a/Devantler.KustomizeCLI/Kustomize.cs
+++ b/Devantler.KustomizeCLI/Kustomize.cs
@@ -26,7 +26,7 @@ public static class Kustomize
       (PlatformID.Unix, Architecture.X64, "linux-x64") => "kustomize-linux-x64",
       (PlatformID.Unix, Architecture.Arm64, "linux-arm64") => "kustomize-linux-arm64",
       (PlatformID.Win32NT, Architecture.X64, "win-x64") => "kustomize-win-x64.exe",
-      (PlatformID.Win32NT, Architecture.X64, "win-arm64") => "kustomize-win-arm64.exe",
+      (PlatformID.Win32NT, Architecture.arm64, "win-arm64") => "kustomize-win-arm64.exe",
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);


### PR DESCRIPTION
Correct the architecture type for Windows ARM64 in the test cases and command retrieval logic.