### PR TITLE
fix: Improve binary path handling and set execute permissions for non-Windows platforms

### DIFF
--- a/Devantler.KustomizeCLI/Kustomize.cs
+++ b/Devantler.KustomizeCLI/Kustomize.cs
@@ -30,9 +30,15 @@ public static class Kustomize
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);
-    return !File.Exists(binaryPath) ?
-      throw new FileNotFoundException($"{binaryPath} not found.") :
-      Cli.Wrap(binaryPath);
+    if (!File.Exists(binaryPath))
+    {
+      throw new FileNotFoundException($"{binaryPath} not found.");
+    }
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      File.SetUnixFileMode(binaryPath, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+    }
+    return Cli.Wrap(binaryPath);
   }
 
   /// <summary>


### PR DESCRIPTION
Enhance the handling of binary paths by ensuring the file exists before proceeding and set execute permissions for non-Windows platforms.