### PR TITLE
fix: Replace Devantler.CLIRunner with CLIWrap for command execution

### DIFF
--- a/src/Devantler.KustomizeCLI/Devantler.KustomizeCLI.csproj
+++ b/src/Devantler.KustomizeCLI/Devantler.KustomizeCLI.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.37" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.KustomizeCLI/Kustomize.cs
+++ b/src/Devantler.KustomizeCLI/Kustomize.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.KustomizeCLI;
 

--- a/src/Devantler.KustomizeCLI/Kustomize.cs
+++ b/src/Devantler.KustomizeCLI/Kustomize.cs
@@ -57,10 +57,12 @@ public static class Kustomize
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    using var stdOut = Console.OpenStandardInput();
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardOutput();
     using var stdErr = Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
+      .WithStandardInputPipe(silent ? PipeSource.Null : PipeSource.FromStream(stdIn))
       .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
       .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
     var result = await command.ExecuteBufferedAsync(cancellationToken);


### PR DESCRIPTION
Switching from Devantler.CLIRunner to CLIWrap improves command execution handling and updates the way output is processed.