### PR TITLE
fix: change Command property to public access modifier

### DIFF
--- a/src/DevantlerTech.KustomizeCLI/Kustomize.cs
+++ b/src/DevantlerTech.KustomizeCLI/Kustomize.cs
@@ -11,7 +11,7 @@ public static class Kustomize
   /// <summary>
   /// The Kustomize CLI command.
   /// </summary>
-  static Command Command
+  public static Command Command
   {
     get
     {


### PR DESCRIPTION
Change the access modifier of the Command property to public to enhance accessibility.